### PR TITLE
User Generated Counterfactual Trajectories

### DIFF
--- a/counterfactuals/01_generate_dataset.py
+++ b/counterfactuals/01_generate_dataset.py
@@ -3,11 +3,12 @@ import copy
 import os
 
 import gym
+from babyai.bot import Bot  # in case we want to use the oracle to generate optimal trajectories
 from tqdm import tqdm
 
-from counterfactuals.dataset import TrajectoryDataset, TrajectoryStep
 from counterfactuals import bots
-from babyai.bot import Bot # in case we want to use the oracle to generate optimal trajectories
+from counterfactuals.dataset import TrajectoryDataset, TrajectoryStep
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/counterfactuals/02_counterfactuals.py
+++ b/counterfactuals/02_counterfactuals.py
@@ -1,0 +1,45 @@
+import argparse
+import copy
+import os
+
+import gym
+from tqdm import tqdm
+
+from counterfactuals.dataset import TrajectoryDataset, TrajectoryStep
+from counterfactuals import bots
+from counterfactuals.user import Interface
+from babyai.bot import Bot
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--load-dir', default=os.path.join('..', 'data', 'pretrained'))
+    parser.add_argument('--save-dir', default=os.path.join('..', 'data', 'counterfactual'))
+    parser.add_argument('--bot-name', default='RandomExplorationBot', type=str)
+    args = parser.parse_args()
+
+    dataset = TrajectoryDataset(args.load_dir)
+    print(f'loading data from {args.load_dir}...')
+    dataset.load()
+    env = next(dataset.trajectory_generator()).state[0]
+
+    if hasattr(bots, args.bot_name):
+        bot_class = getattr(bots, args.bot_name)
+    elif env.bot_name.lower() == "bot":
+        bot_class = Bot
+    else:
+        raise ValueError("Invalid bot name")
+
+    def policy_generator(env):
+        return bots.Policy(bot_class, env)
+
+    counterfactual_dataset = TrajectoryDataset(args.save_dir)
+
+    print('starting user interface...')
+    Interface(policy_generator, dataset, counterfactual_dataset)
+
+    counterfactual_dataset.save()
+
+
+if __name__ == '__main__':
+    main()

--- a/counterfactuals/02_counterfactuals.py
+++ b/counterfactuals/02_counterfactuals.py
@@ -1,14 +1,11 @@
 import argparse
-import copy
 import os
 
-import gym
-from tqdm import tqdm
-
-from counterfactuals.dataset import TrajectoryDataset, TrajectoryStep
-from counterfactuals import bots
-from counterfactuals.user import Interface
 from babyai.bot import Bot
+
+from counterfactuals import bots
+from counterfactuals.dataset import TrajectoryDataset
+from counterfactuals.user import Interface
 
 
 def main():

--- a/counterfactuals/bots.py
+++ b/counterfactuals/bots.py
@@ -1,0 +1,370 @@
+from babyai.bot import Bot, ExploreSubgoal
+from gym_minigrid.minigrid import MiniGridEnv
+import copy
+import numpy as np
+import random
+import torch.nn as nn
+
+"""
+File contains bots with certain suboptimal biases.
+
+Each bot takes in a BabyAI env, which for consistency with the original Bot class is called a mission.
+"""
+
+
+class Policy(nn.Module):
+    """Wrapper around the bot so it uses the expected policy interface."""
+    def __init__(self, bot_class, env):
+        super().__init__()
+        self.bot_class = bot_class
+        self.env = env
+        self.reset()
+
+    def forward(self, _):
+        """Ignore the current state passed in and return the bot's next suggested action."""
+        return self.bot.replan()
+
+    def reset(self):
+        """When we reset the environment, we also have to reset the bot."""
+        self.bot = self.bot_class(self.env)
+
+
+class DoubleForwardBot(Bot):
+    """
+    Bot which repeats its action whenever it steps forward.
+
+    Seems to succeed every time on level GoTo.
+    """
+
+    def __init__(self, mission):
+        super().__init__(mission)
+        self.forward_next_turn = False
+        self.past_action = None
+
+    def replan(self, action_taken=None):
+        past_action = action_taken if action_taken is not None else self.past_action
+        proposed_action = super().replan(past_action)
+        # If we went forward last turn, go forward again.
+        if self.forward_next_turn:
+            action = MiniGridEnv.Actions.forward
+            self.forward_next_turn = False
+        # Otherwise take the recommended action
+        else:
+            action = proposed_action
+            if action == MiniGridEnv.Actions.forward:
+                self.forward_next_turn = True
+        self.past_action = action
+        return action
+
+
+class StraightNotRightBot(Bot):
+    """
+    Bot which can't turn right. If it tries to turn right,
+    it will go straight instead.
+    It doesn't incorporate this disability into its planner.
+
+    Seems to succeed every time on level GoTo.
+    """
+
+    def __init__(self, mission):
+        super().__init__(mission)
+        self.past_action = None
+
+    def replan(self, action_taken=None):
+        past_action = action_taken if action_taken is not None else self.past_action
+        proposed_action = super().replan(past_action)
+        # If we're about to turn right, go forward instead
+        if proposed_action == MiniGridEnv.Actions.right:
+            action = MiniGridEnv.Actions.forward
+        else:
+            action = proposed_action
+        self.past_action = action
+        return action
+
+
+class LeftNotRightBot(Bot):
+    """
+    Bot which can't turn right. If it tries to turn right,
+    it will go left instead.
+    It doesn't incorporate this disability into its planner.
+
+    Seems to succeed every time on level GoTo.
+    """
+
+    def __init__(self, mission):
+        super().__init__(mission)
+        self.past_action = None
+
+    def replan(self, action_taken=None):
+        past_action = action_taken if action_taken is not None else self.past_action
+        proposed_action = super().replan(past_action)
+        # If we're about to turn right, go left instead
+        if proposed_action == MiniGridEnv.Actions.right:
+            action = MiniGridEnv.Actions.left
+        else:
+            action = proposed_action
+        self.past_action = action
+        return action
+
+
+class NoMemoryBot(Bot):  # Seems to fail every time
+    """
+    Bot which restarts its planning algorithm from scratch every timestep.
+
+    Seems to fail every time on level GoTo.
+    """
+
+    def __init__(self, mission):
+        super().__init__(mission)
+        self.mission = mission
+
+    def replan(self, action_taken=None):
+        # Create an entirely new bot each time we need to plan
+        bot = Bot(self.mission)
+        action = bot.replan()
+        return action
+
+
+class EpsilonRandomBot(Bot):
+    """
+    Bot which takes a random action some random percent of the time.
+
+    Succeeds almost every time on level GoTo.
+    """
+
+    def __init__(self, mission, epsilon=0.3):
+        super().__init__(mission)
+        self.epsilon = epsilon
+        self.past_action = None
+
+    def replan(self, action_taken=None):
+        past_action = action_taken if action_taken is not None else self.past_action
+        action = super().replan(past_action)
+        # With probability epsilon, choose an action randomly.  Otherwise to the suggested action.
+        if np.random.uniform() < self.epsilon:
+            action = random.choice([MiniGridEnv.Actions.left, MiniGridEnv.Actions.right, MiniGridEnv.Actions.forward])
+        self.past_action = action
+        return action
+
+
+class RandomBot(Bot):  # Seems to fail every time
+    """
+    Bot which takes a random action all the time.
+
+    Fails almost every time on all but the simplest environments.
+    """
+
+    def __init__(self, mission):
+        pass
+
+    def replan(self, action_taken=None):
+        action = random.choice(list(MiniGridEnv.Actions))
+        return action
+
+
+class RandomStraightBot(Bot):
+    """
+    Bot which chooses a random direction and heads in it for between 1 and 4 timesteps.
+
+    Fails almost every time on all but the simplest environments.
+    """
+
+    def __init__(self, mission):
+        self.curr_action = None
+        self.steps_remaining = 0
+
+    def replan(self, action_taken=None):
+        # If we're not in the middle of a string of actions, choose an action and how many steps to take it for
+        if self.steps_remaining == 0:
+            self.curr_action = random.choice(list(MiniGridEnv.Actions))
+            self.steps_remaining = random.choice([0, 1, 2, 3])
+        else:
+            # Otherwise, take the current action again.
+            self.steps_remaining -= 1
+        return self.curr_action
+
+
+class GreyBlindBot(Bot):
+    """
+    Bot which cannot see gray obstacles.
+    """
+    def __init__(self, mission):
+        """Keep a copy of the real mission, which will get updated as the agent takes actions.
+            Also keep a modifid mission copy with gray obstacles blanked out. """
+        self.original_mission = mission
+        mission_copy = self.update_mission()
+        self.past_action = None
+        super().__init__(mission_copy)
+
+    def update_mission(self):
+        """Make a modifid mission copy with gray obstacles blanked out."""
+        mission_copy = copy.deepcopy(self.original_mission)
+        # Remove gray objects
+        for i, item in enumerate(mission_copy.grid.grid):
+            if item is not None and item.color and item.color == 'grey' and not item.type == "wall":
+                mission_copy.grid.grid[i] = None
+        # If the goal is gray, remove that too
+        if mission_copy.instrs.desc.color == 'grey':
+            mission_copy.instrs.desc.obj_poss = []
+            # for i, j in mission_copy.instrs.desc.obj_poss:
+            #     mission_copy.instrs.desc.
+            #     # check if vis_mask exists (it won't the first timestep)
+            #     if hasattr(self, 'vis_mask'):
+            #         self.vis_mask[i, j] = False
+        return mission_copy
+
+    def replan(self, action_taken=None):
+        past_action = action_taken if action_taken is not None else self.past_action
+        mission_copy = self.update_mission()
+        self.mission = mission_copy
+        # Since the goal may sometimes be to find a gray object and we don't
+        # have any gray objects, we may get an assertion error that there is
+        # nowhere left to explore.  If this happens, reset the bot.
+        try:
+            action = super().replan(past_action)
+        except AssertionError:
+            self.__init__(self.original_mission)
+            action = self.replan()
+        self.past_action = past_action
+        return action
+
+
+class WallBlindBot(Bot):
+    """
+    Bot which cannot see walls until it is right in front of them.
+
+    Has about 0.27 success rate on GoTo.
+    """
+
+    def __init__(self, mission):
+        self.original_mission = mission
+        self.wall_visibliity = self.initialize_wall_visibility()
+        mission_copy = self.update_mission()
+        self.past_action = None
+        super().__init__(mission_copy)
+
+    def initialize_wall_visibility(self):
+        """"Create a list representing the visibility of all items.  Start with everything visible except walls."""
+        wall_visibility = []
+        for item in self.original_mission.grid.grid:
+            if item is None or not item.type == 'wall':
+                wall_visibility.append(True)
+            else:
+                wall_visibility.append(False)
+        return wall_visibility
+
+    def update_wall_visibility(self):
+        """If the agent is right in front of a wall, make that wall visible."""
+        i, j = self.original_mission.front_pos
+        index = self.original_mission.grid.grid[j * self.original_mission.width + i]
+        self.wall_visibliity[index] = True
+        pass
+
+    def update_mission(self):
+        """Create a copy of the real mission in with walls with visibility==False are blanked out."""
+        mission_copy = copy.deepcopy(self.original_mission)
+        for i, (item, visibility) in enumerate(zip(mission_copy.grid.grid, self.wall_visibliity)):
+            if item is not None and item.type == 'wall' and visibility is False:
+                mission_copy.grid.grid[i] = None
+        return mission_copy
+
+    def replan(self, action_taken=None):
+        """Update the missiong grid to hide walls, then suggest a new action."""
+        past_action = action_taken if action_taken is not None else self.past_action
+        mission_copy = self.update_mission()
+        self.mission = mission_copy
+        action = super().replan(past_action)
+        self.past_action = past_action
+        return action
+
+
+
+
+class RandomExplorationBot(Bot):
+    """
+    Bot which explores randomly when its goal is not in sight
+
+    Has about 0.76 success on GoTo.
+    """
+
+    def __init__(self, mission):
+        super().__init__(mission)
+        self.past_action = None
+
+    def replan(self, action_taken=None):
+        past_action = action_taken if action_taken is not None else self.past_action
+        proposed_action = super().replan(past_action)
+        # Stack holds current subtasks.  When the subtask is exploration, choose randomly instead.
+        if self.stack and self.stack[-1].is_exploratory():
+            action = random.choice([MiniGridEnv.Actions.left, MiniGridEnv.Actions.right, MiniGridEnv.Actions.forward])
+        else:
+            action = proposed_action
+        self.past_action = action
+        return action
+
+
+class MyopicBot(Bot):
+    """
+    Bot with a field of view of 5 squares (not 7)
+
+    Has 1.0 success rate on GoTo.
+    """
+
+    def __init__(self, mission):
+        self.mission_copy = copy.deepcopy(mission)
+        self.mission_copy.agent_view_size = 5
+        self.past_action = None
+        super().__init__(self.mission_copy)
+
+    def replan(self, action_taken=None):
+        past_action = action_taken if action_taken is not None else self.past_action
+        # The mission copy does not update automatically, so we step it here so it's consistent with the real one.
+        if past_action is not None:
+            self.mission_copy.step(past_action)
+        action = super().replan(past_action)
+        self.past_action = action
+        return action
+
+
+class ExploreFirstBot(Bot):
+    """
+    Bot which explores the entire grid before it does anything else.
+
+    Gets about .28 success on GoTo.
+    """
+
+    def __init__(self, mission):
+        super().__init__(mission)
+        self.explored_everything = False
+        self.past_action = None
+
+    def replan(self, action_taken=None):
+        past_action = action_taken if action_taken is not None else self.past_action
+        # Find the action we'd take if we weren't exploring first.
+        proposed_action = super().replan(past_action)
+        action = None
+        if not self.explored_everything:
+            try:
+                # Copy the real stack so we can replace it unmodified later
+                original_stack = self.stack
+                self.stack = []
+                # Add exploration onto the stack.  We need to do this stack iteration
+                # since the ExplorationSubgoal often creates another subgoal which it
+                # puts on the stack (e.g. getting to a particular location).
+                # This loop should alwyas produce an action unless all states are explored.
+                self.stack = [ExploreSubgoal(self)]
+                while self.stack:
+                    subgoal = self.stack[-1]
+                    action = subgoal.replan_before_action()
+                    if action is not None:
+                        break
+                if action is None:
+                    raise ValueError("Action should not be none.")
+                self.stack = original_stack
+            except AssertionError:  # Raised when there's nothing left to explore
+                self.explored_everything = True
+                self.stack = original_stack
+        if action is None:
+            action = proposed_action
+        self.past_action = past_action
+        return action

--- a/counterfactuals/user.py
+++ b/counterfactuals/user.py
@@ -1,16 +1,13 @@
-import numpy as np
-import gym
-import gym_minigrid
-from gym_minigrid.wrappers import *
-from gym_minigrid.window import Window
-import babyai
 import copy
+
+from gym_minigrid.window import Window
 
 from counterfactuals.dataset import TrajectoryDataset, Trajectory, TrajectoryStep
 
 
 class Navigator:
     def __init__(self, index, min_index, max_index):
+        """Used as a simple way to constrain movement through time"""
         self.index = index
         self.min = min_index
         self.max = max_index
@@ -34,6 +31,8 @@ class Navigator:
 
 
 class TrajectoryNavigator(Navigator):
+    """Navigates the prior trajectory data"""
+
     def __init__(self, trajectory: Trajectory):
         self.trajectory = trajectory
         self.index = 0
@@ -58,6 +57,7 @@ class TrajectoryNavigator(Navigator):
 
 
 class CounterfactualNavigator(Navigator):
+    """Creates a counterfactual trajectory based on user action. Keeps track of a stack of states"""
 
     def __init__(self, policy_factory, episode: int, step: int, start: TrajectoryStep, max_steps=100):
         self.policy_factory = policy_factory
@@ -113,6 +113,36 @@ class CounterfactualNavigator(Navigator):
 
 
 class Interface:
+    """
+    User interface for generating counterfactual states and actions.
+    For each trajectory:
+        The user can use the `a` and `d` keys to go backward and forward in time to a specific state they wish to
+        generate a counterfaction explanation from. Once a specific state is found, the user presses `w` to launch the
+        counterfactual mode.
+        In the counterfactual mode, the user can control the agent using the keyboard. Once satisfied with their
+        progress, the user can give up control to the bot to finish the episode by pressing `w`.
+
+        The keys for controlling the agent are summarized here:
+
+        escape: quit the program
+
+        view mode:
+            d: next time step
+            a: previous time step
+            w: select time step and go to counterfactual mode
+
+        counterfactual mode:
+            left:          turn counter-clockwise
+            right:         turn clockwise
+            up:            go forward
+            space:         toggle
+            pageup or x:   pickup
+            pagedown or z: drop
+            enter or q:    done (should not use)
+            a:             undo action
+            w:             roll out to the end of the episode and move to next episode
+    """
+
     def __init__(self, policy_factory, original_dataset: TrajectoryDataset, counterfactual_dataset: TrajectoryDataset):
         self.policy_factory = policy_factory
         self.dataset = original_dataset
@@ -142,6 +172,7 @@ class Interface:
         img = env.render('rgb_array', tile_size=32)
         # else:
         # img = step.observation['image']
+        # TODO later: figure out when to use the observation instead.
 
         self.window.show_img(img)
 
@@ -184,6 +215,7 @@ class Interface:
 
         if event.key == 'escape':
             self.window.close()
+            exit()
             return
 
         # if event.key == 'backspace':

--- a/counterfactuals/user.py
+++ b/counterfactuals/user.py
@@ -1,0 +1,238 @@
+import numpy as np
+import gym
+import gym_minigrid
+from gym_minigrid.wrappers import *
+from gym_minigrid.window import Window
+import babyai
+import copy
+
+from counterfactuals.dataset import TrajectoryDataset, Trajectory, TrajectoryStep
+
+
+class Navigator:
+    def __init__(self, index, min_index, max_index):
+        self.index = index
+        self.min = min_index
+        self.max = max_index
+
+    def forward(self):
+        if self.index + 1 > self.max:
+            raise ValueError(f'Tried to go past the maximum steps {self.max}')
+        self.index += 1
+        end = self.index == self.max
+        return end
+
+    def backward(self):
+        if self.index - 1 < self.min:
+            raise ValueError(f'Tried to go past the minimum steps {self.min}')
+        self.index -= 1
+        end = self.index == self.min
+        return end
+
+    def step(self):
+        raise NotImplementedError
+
+
+class TrajectoryNavigator(Navigator):
+    def __init__(self, trajectory: Trajectory):
+        self.trajectory = trajectory
+        self.index = 0
+        self.episode = trajectory.episode
+        self._step = trajectory.step
+        self._state = trajectory.state
+        self._observation = trajectory.observation
+        self._action = trajectory.action
+        self._reward = trajectory.reward
+        self._done = trajectory.done
+        self._info = trajectory.info
+        super().__init__(0, self._step[0], self._step[-1])
+
+    def step(self):
+        state = self._state[self.index]
+        obs = self._observation[self.index]
+        action = self._action[self.index]
+        reward = self._reward[self.index]
+        done = self._done[self.index]
+        info = self._info[self.index]
+        return TrajectoryStep(state, obs, action, reward, done, info)
+
+
+class CounterfactualNavigator(Navigator):
+
+    def __init__(self, policy_factory, episode: int, step: int, start: TrajectoryStep, max_steps=100):
+        self.policy_factory = policy_factory
+        self.episode = episode
+        self.start = start
+
+        self.stack = [(episode, step, start)]
+        super().__init__(step, step, step + max_steps)
+
+    def current(self):
+        cur = self.stack[-1]
+        episode: int = cur[0]
+        step: int = cur[1]
+        traj_step: TrajectoryStep = cur[2]
+        return episode, step, traj_step
+
+    def step(self):
+        return self.current()[2]
+
+    def forward(self, action):
+        end = super().forward()
+        episode, step, traj_step = self.current()
+        if traj_step.done:
+            raise ValueError('Trajectory already finished! Cannot perform further actions!')
+        env = copy.deepcopy(traj_step.state)
+        obs, reward, done, info = env.step(getattr(env.actions, action))
+        next_traj_step = TrajectoryStep(env, obs, action, reward, done, info)
+        self.stack.append((episode, step + 1, next_traj_step))
+        return end or done
+
+    def backward(self):
+        end = super().backward()
+        self.stack.pop(-1)
+        return end
+
+    def rollout(self):
+        episode, step, traj_step = self.current()
+        done = traj_step.done
+        env = copy.deepcopy(traj_step.state)
+        policy = self.policy_factory(env)
+        obs = traj_step.observation
+        while not done:
+            action = policy(obs)
+            obs, reward, done, info = env.step(action)
+            next_traj_step = TrajectoryStep(copy.deepcopy(env), obs, action, reward, done, info)
+            step += 1
+            self.stack.append((episode, step, next_traj_step))
+
+    def store(self, dataset: TrajectoryDataset):
+        for i in range(1, len(self.stack)):
+            episode, step, traj_step = self.stack[i]
+            dataset.append(episode, step, traj_step)
+
+
+class Interface:
+    def __init__(self, policy_factory, original_dataset: TrajectoryDataset, counterfactual_dataset: TrajectoryDataset):
+        self.policy_factory = policy_factory
+        self.dataset = original_dataset
+        self.counterfactual_dataset = counterfactual_dataset
+        self.trajectory_generator = self.dataset.trajectory_generator()
+        self.navigator: TrajectoryNavigator = None
+        self.window = None
+        self.is_counterfactual = False
+        self.run()
+
+    def run(self):
+        for i, trajectory in enumerate(self.trajectory_generator):
+            self.saved = False
+            self.is_counterfactual = False
+            self.navigator = TrajectoryNavigator(trajectory)
+            self.window = Window(f'Trajectory {i}')
+            self.window.reg_key_handler(self.key_handler)
+            self.reset()
+            self.window.show(block=True)
+            if not self.saved:
+                raise Exception('Continued without saving the trajectory!')
+
+    def redraw(self):
+        step: TrajectoryStep = self.navigator.step()
+        # if not self.agent_view:
+        env = step.state
+        img = env.render('rgb_array', tile_size=32)
+        # else:
+        # img = step.observation['image']
+
+        self.window.show_img(img)
+
+    def step(self, action=None):
+        if action is None:
+            self.navigator.forward()
+        else:
+            assert isinstance(self.navigator, CounterfactualNavigator)
+            self.navigator.forward(action)
+        self.redraw()
+
+    def backward(self):
+        self.navigator.backward()
+        self.redraw()
+
+    def reset(self):
+        env = self.navigator.step().state
+
+        if hasattr(env, 'mission'):
+            print('Mission: %s' % env.mission)
+            self.window.set_caption(env.mission)
+
+        self.redraw()
+
+    def select(self):
+        new_navigator = CounterfactualNavigator(
+            self.policy_factory, self.navigator.episode, self.navigator.index, self.navigator.step())
+        self.navigator = new_navigator
+        self.is_counterfactual = True
+        print(f'Starting counterfactual trajectory from {self.navigator.index}')
+        self.redraw()
+
+    def save_trajectory(self):
+        assert isinstance(self.navigator, CounterfactualNavigator)
+        self.navigator.store(self.counterfactual_dataset)
+        self.saved = True
+
+    def key_handler(self, event):
+        print('pressed', event.key)
+
+        if event.key == 'escape':
+            self.window.close()
+            return
+
+        # if event.key == 'backspace':
+        #     self.reset()
+        #     return
+        if self.is_counterfactual:
+            if event.key == 'left':
+                self.step('left')
+                return
+            if event.key == 'right':
+                self.step('right')
+                return
+            if event.key == 'up':
+                self.step('forward')
+                return
+
+            # Spacebar
+            if event.key == ' ':
+                self.step('toggle')
+                return
+            if event.key == 'pageup' or event.key == 'x':
+                self.step('pickup')
+                return
+            if event.key == 'pagedown' or event.key == 'z':
+                self.step('drop')
+                return
+
+            if event.key == 'enter' or event.key == 'q':
+                self.step('done')
+                return
+
+            if event.key == 'w':
+                self.navigator.rollout()
+                self.save_trajectory()
+                self.window.close()
+
+            if event.key == 'a':
+                self.backward()
+                return
+
+        if not self.is_counterfactual:
+            if event.key == 'd':
+                self.step()
+                return
+
+            if event.key == 'a':
+                self.backward()
+                return
+
+            if event.key == 'w':
+                self.select()
+                return

--- a/tests/counterfactuals/bots.py
+++ b/tests/counterfactuals/bots.py
@@ -1,0 +1,42 @@
+import gym
+import pytest
+from counterfactuals.bots import *
+from gym_minigrid.minigrid import MiniGridEnv
+
+# Make sure all the bots run for at least one step
+@pytest.mark.parametrize('bot_class', [DoubleForwardBot,
+                                       StraightNotRightBot,
+                                       LeftNotRightBot,
+                                       NoMemoryBot,
+                                       EpsilonRandomBot,
+                                       RandomBot,
+                                       RandomStraightBot,
+                                       GreyBlindBot,
+                                       WallBlindBot,
+                                       RandomExplorationBot,
+                                       MyopicBot,
+                                       ExploreFirstBot])
+def test_bots(bot_class):
+    env = gym.make("BabyAI-GoToLocal-v0")
+    env.reset()
+    bot = bot_class(env)
+    action = bot.replan()
+    assert action in list(MiniGridEnv.Actions)
+
+def test_policy():
+    env = gym.make("BabyAI-GoToLocal-v0")
+    state = env.reset()
+    bot = DoubleForwardBot(env)
+    policy = Policy(DoubleForwardBot, env)
+    # The DoubleForwardBot bot is deterministic, so we should get the same response by calling forward
+    # and calling the bot's "replan" directly.
+    bot_action = bot.replan()
+    policy_action = policy(state)
+    assert bot_action == policy_action
+
+    # Call reset and confirm we've created a new bot
+    old_bot = policy.bot
+    assert old_bot is old_bot
+    policy.reset()
+    new_bot = policy.bot
+    assert not old_bot is new_bot


### PR DESCRIPTION
Created a user interface for generating counterfactual actions:
From the description in Interface class in user.py:
```
    User interface for generating counterfactual states and actions.
    For each trajectory:
        The user can use the `a` and `d` keys to go backward and forward in time to a specific state they wish to
        generate a counterfaction explanation from. Once a specific state is found, the user presses `w` to launch the
        counterfactual mode.
        In the counterfactual mode, the user can control the agent using the keyboard. Once satisfied with their
        progress, the user can give up control to the bot to finish the episode by pressing `w`.

        The keys for controlling the agent are summarized here:

        escape: quit the program

        view mode:
            d: next time step
            a: previous time step
            w: select time step and go to counterfactual mode

        counterfactual mode:
            left:          turn counter-clockwise
            right:         turn clockwise
            up:            go forward
            space:         toggle
            pageup or x:   pickup
            pagedown or z: drop
            enter or q:    done (should not use)
            a:             undo action
            w:             roll out to the end of the episode and move to next episode
```